### PR TITLE
In place array modification

### DIFF
--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -4912,6 +4912,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
 			zend_argument_type_error(i + 1, "must be of type array, %s given", zend_zval_value_name(&args[i]));
 			arr_argc = i; /* only free up to i - 1 */
+			in_place = false;
 			goto out;
 		}
 		hash = Z_ARRVAL(args[i]);
@@ -5308,6 +5309,7 @@ static void php_array_diff(INTERNAL_FUNCTION_PARAMETERS, int behavior, int data_
 		if (Z_TYPE(args[i]) != IS_ARRAY) {
 			zend_argument_type_error(i + 1, "must be of type array, %s given", zend_zval_value_name(&args[i]));
 			arr_argc = i; /* only free up to i - 1 */
+			in_place = false;
 			goto out;
 		}
 		hash = Z_ARRVAL(args[i]);

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3865,7 +3865,8 @@ static zend_always_inline void php_array_replace_wrapper(INTERNAL_FUNCTION_PARAM
 /* }}} */
 
 /* Returns true if it's possible to do an in-place array modification, preventing a costly copy.
- * It also modifies the CV to prevent freeing it upon assigning. */
+ * It also modifies the CV to prevent freeing it upon assigning.
+ * If this returns true you need to add a ref at the end of the modification for the return value. */
 static bool prepare_in_place_array_modify_if_possible(const zend_execute_data *execute_data, const zval *arg)
 {
 	/* 2 refs: the CV and the argument; or 1 ref for a temporary passed as argument */
@@ -3900,7 +3901,7 @@ static bool prepare_in_place_array_modify_if_possible(const zend_execute_data *e
 		}
 		/* Must set the CV to NULL so we don't destroy the array on assignment */
 		ZVAL_NULL(var);
-		/* Make RC 1 such that the array may be modified, update_refcount will make sure the refcount gets back to 2 at the end */
+		/* Make RC 1 such that the array may be modified */
 		GC_DELREF(Z_ARRVAL_P(arg));
 	}
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3842,11 +3842,6 @@ static bool prepare_in_place_array_modify_if_possible(const zend_execute_data *e
 	}
 
 	if (refcount == 2) {
-		/* Potentially possible with fake frames during optimization */
-		if (UNEXPECTED(!execute_data->prev_execute_data)) {
-			return false;
-		}
-
 		const zend_op *call_opline = execute_data->prev_execute_data->opline;
 		const zend_op *next_opline = call_opline + 1;
 

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -3869,7 +3869,7 @@ static bool prepare_in_place_array_modify_if_possible(const zend_execute_data *e
 	return true;
 }
 
-static bool set_return_value_dup_or_in_place(const zend_execute_data *execute_data, const zval *arg, zval *return_value)
+static bool set_return_value_array_dup_or_in_place(const zend_execute_data *execute_data, const zval *arg, zval *return_value)
 {
 	if (prepare_in_place_array_modify_if_possible(execute_data, arg)) {
 		RETVAL_ARR(Z_ARRVAL_P(arg));
@@ -3903,7 +3903,7 @@ static zend_always_inline void php_array_replace_wrapper(INTERNAL_FUNCTION_PARAM
 
 	/* copy first array if necessary */
 	arg = args;
-	bool update_refcount = set_return_value_dup_or_in_place(execute_data, arg, return_value);
+	bool update_refcount = set_return_value_array_dup_or_in_place(execute_data, arg, return_value);
 	dest = Z_ARRVAL_P(return_value);
 
 	if (recursive) {
@@ -4650,7 +4650,7 @@ PHP_FUNCTION(array_unique)
 
 	cmp = php_get_data_compare_func_unstable(sort_type, 0);
 
-	bool update_refcount = set_return_value_dup_or_in_place(execute_data, array, return_value);
+	bool update_refcount = set_return_value_array_dup_or_in_place(execute_data, array, return_value);
 
 	/* create and sort array with pointers to the target_hash buckets */
 	arTmp = pemalloc((Z_ARRVAL_P(array)->nNumOfElements + 1) * sizeof(struct bucketindex), GC_FLAGS(Z_ARRVAL_P(array)) & IS_ARRAY_PERSISTENT);
@@ -4955,7 +4955,7 @@ static void php_array_intersect(INTERNAL_FUNCTION_PARAMETERS, int behavior, int 
 
 	/* copy the argument array if necessary */
 	if (in_place) {
-		in_place = set_return_value_dup_or_in_place(execute_data, &args[0], return_value);
+		in_place = set_return_value_array_dup_or_in_place(execute_data, &args[0], return_value);
 	} else {
 		RETVAL_ARR(zend_array_dup(Z_ARRVAL(args[0])));
 	}
@@ -5351,7 +5351,7 @@ static void php_array_diff(INTERNAL_FUNCTION_PARAMETERS, int behavior, int data_
 
 	/* copy the argument array if necessary */
 	if (in_place) {
-		in_place = set_return_value_dup_or_in_place(execute_data, &args[0], return_value);
+		in_place = set_return_value_array_dup_or_in_place(execute_data, &args[0], return_value);
 	} else {
 		RETVAL_ARR(zend_array_dup(Z_ARRVAL(args[0])));
 	}

--- a/ext/standard/array.c
+++ b/ext/standard/array.c
@@ -5069,6 +5069,10 @@ out:
 
 	efree(ptrs);
 	efree(lists);
+
+	if (in_place) {
+		GC_ADDREF(Z_ARRVAL_P(return_value));
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
Benchmark script: https://gist.github.com/nielsdos/ae5a2dddc53c61749ae31c908aa78e98

This patch optimizes the `$x = array_function($x, ...)` pattern and the `$x = array_function(temporary, ...)` pattern for these functions: array_merge, array_unique, array_replace, array_diff and array_intersect.
With these limitations:
- no user-supplied callbacks as that runs code which may manipulate the array or may observe the side effect of this optimization.
- no SORT_STRING optimization for array_unique
- array_merge optimization works only if the array is packed and hole-less

Looking at the assembly of prepare_in_place_array_modify_if_possible() it looks pretty lightweight, about 91 bytes or 27 instructions on my x86-64 Linux laptop.