### PR TITLE
Use 64-bit time on 32-bit Windows

### DIFF
--- a/win32/build/config.w32.h.in
+++ b/win32/build/config.w32.h.in
@@ -121,13 +121,6 @@
 #define HAVE_INET_PTON 1
 #define HAVE_INET_NTOP 1
 
-/* vs.net 2005 has a 64-bit time_t.  This will likely break
- * 3rdParty libs that were built with older compilers; switch
- * back to 32-bit */
-#ifndef _WIN64
-# define _USE_32BIT_TIME_T 1
-#endif
-
 #define _REENTRANT 1
 
 #define HAVE_GETRUSAGE

--- a/win32/build/confutils.js
+++ b/win32/build/confutils.js
@@ -3255,13 +3255,8 @@ function toolset_setup_common_cflags()
 		ADD_FLAG("CFLAGS", " /FD ");
 
 		// fun stuff: MS deprecated ANSI stdio and similar functions
-		// disable annoying warnings.  In addition, time_t defaults
-		// to 64-bit.  Ask for 32-bit.
-		if (TARGET_ARCH == 'x86') {
-			ADD_FLAG('CFLAGS', ' /wd4996 /D_USE_32BIT_TIME_T=1 ');
-		} else {
-			ADD_FLAG('CFLAGS', ' /wd4996 ');
-		}
+		// disable annoying warnings.
+		ADD_FLAG('CFLAGS', ' /wd4996 ');
 
 		if (PHP_DEBUG == "yes") {
 			// Set some debug/release specific options


### PR DESCRIPTION
VS 2005 introduced 64-bit time. This was disabled since then to prevent libraries compiled with older versions from causing breaks. Since the current development version of PHP requires a much more modern compiler and 2005 has been long in the past, it makes sense to use 64-bit time by default to prevent Y2038 problems.