### PR TITLE
Avoid refcounted copy in _object_properties_init() for internal classes

### DIFF
--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -1610,8 +1610,11 @@ static zend_always_inline void _object_properties_init(zend_object *object, zend
 		zval *end = src + class_type->default_properties_count;
 
 		if (UNEXPECTED(class_type->type == ZEND_INTERNAL_CLASS)) {
+			/* We don't have to account for refcounting because
+			 * zend_declare_typed_property() disallows refcounted defaults for internal classes. */
 			do {
-				ZVAL_COPY_OR_DUP_PROP(dst, src);
+				ZEND_ASSERT(!Z_REFCOUNTED_P(src));
+				ZVAL_COPY_VALUE_PROP(dst, src);
 				src++;
 				dst++;
 			} while (src != end);


### PR DESCRIPTION
This currently uses ZVAL_COPY_OR_DUP, which copies the value and handles refcounting. However, internal classes cannot have refcounted default properties because of constraints imposed by
zend_declare_typed_property(). So copying the value is sufficient.

While this doesn't really improve the performance for our benchmarks, it improves performance for cases where a lot of temporary internal objects are instantiated. For example, when instantiating DOM classes: DOM objects are transient, so lots of temporary objects are created.

I have a variant on my fork that adds a CE flag to extend this to user classes too (https://github.com/nielsdos/php-src/pull/55). But the performance win is so small that I'm not sure that's useful.