### PR TITLE
Fix mysqlnd pipe crash

### DIFF
--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -141,6 +141,7 @@ MYSQLND_METHOD(mysqlnd_vio, open_pipe)(MYSQLND_VIO * const vio, const MYSQLND_CS
 	EG(regular_list).pDestructor = NULL;
 	zend_hash_index_del(&EG(regular_list), net_stream->res->handle); /* ToDO: should it be res->handle, do streams register with addref ?*/
 	EG(regular_list).pDestructor = origin_dtor;
+	efree(net_stream->res);
 	net_stream->res = NULL;
 
 	DBG_RETURN(net_stream);

--- a/ext/mysqlnd/mysqlnd_vio.c
+++ b/ext/mysqlnd/mysqlnd_vio.c
@@ -652,15 +652,11 @@ MYSQLND_METHOD(mysqlnd_vio, close_stream)(MYSQLND_VIO * const net, MYSQLND_STATS
 		bool pers = net->persistent;
 		DBG_INF_FMT("Freeing stream. abstract=%p", net_stream->abstract);
 		/* We removed the resource from the stream, so pass FREE_RSRC_DTOR now to force
-		 * destruction to occur during shutdown, because it won't happen through the resource. */
-		/* TODO: The EG(active) check here is dead -- check IN_SHUTDOWN? */
-		if (pers && EG(active)) {
+		 * destruction to occur during shutdown, because it won't happen through the resource
+		 * because we removed the resource from the EG resource list(s). */
+		if (pers) {
 			php_stream_free(net_stream, PHP_STREAM_FREE_CLOSE_PERSISTENT | PHP_STREAM_FREE_RSRC_DTOR);
 		} else {
-			/*
-			  otherwise we will crash because the EG(persistent_list) has been freed already,
-			  before the modules are shut down
-			*/
 			php_stream_free(net_stream, PHP_STREAM_FREE_CLOSE | PHP_STREAM_FREE_RSRC_DTOR);
 		}
 		net->data->m.set_stream(net, NULL);


### PR DESCRIPTION
The individual commits have descriptions that explain the change. This fixes the bug fully on the master branch.
I tested this with both persistent and non-persistent connections. As mysqlnd's stream handling is a bit tricky and has some hacks, it's best to review this with at least 2 people.

As for backporting: All commits except the first one can be backported to stable branches I think, which means that in that case it's fixed on stable branches that use NTS. On ZTS it won't always work: only the non-persistent connections are fully fixed.